### PR TITLE
Fix crash when comparing

### DIFF
--- a/FolderStructureAnalyser/Components/AnalyserPanels/FolderStructureComparerCtrl.cs
+++ b/FolderStructureAnalyser/Components/AnalyserPanels/FolderStructureComparerCtrl.cs
@@ -117,7 +117,28 @@ namespace FolderStructureAnalyser.Components.AnalyserPanels
         /// <param name="differences">The list of differences to show the user.</param>
         private void updateDataSource(BindingList<StructureDifference> differences)
         {
-            gridControl.DataSource = differences;
+            /* For some reason, assigning the differences directly to the
+             * data-source, like so:
+             * 
+             * gridControl.DataSource = differences;
+             * 
+             * ... raises the exception below:
+             * 
+             * System.Reflection.TargetInvocationException: 'Property accessor 'FullName' on object 'System.IO.FileInfo' threw the following exception:'Object does not match target type.''
+             * TargetException: Object does not match target type.
+             * 
+             * I do not know why, but assigning a new, empty binding list, and
+             * then adding all the differences, one by one, seems to work.
+             * 
+             * I speculate that the grid-control wants to be able to raise some
+             * event for every row added to it, and that it can't do that when
+             * all rows are added as a collection?
+             */
+            gridControl.DataSource = new BindingList<StructureDifference>();
+            foreach (var diff in differences)
+            {
+                (gridControl.DataSource as BindingList<StructureDifference>).Add(diff);
+            }
         }
 
         /// <summary>

--- a/FolderStructureAnalyser/Program.cs
+++ b/FolderStructureAnalyser/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Windows.Forms;
 using DevExpress.XtraEditors;
 using FolderStructureAnalyser.Components;
@@ -15,6 +16,13 @@ namespace FolderStructureAnalyser
         [STAThread]
         static void Main()
         {
+            //By setting the default thread culture to English, the exceptions
+            //raised will be in English and not in Swedish (or whatever
+            //language the local computer has), making error researching
+            //(aka googling) easier.
+            CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
+            CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
+
             WindowsFormsSettings.ScrollUIMode = ScrollUIMode.Fluent;
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);


### PR DESCRIPTION
Added workaround for the problem causing the program to throw an exception when the folder structure differences are added to the grid.